### PR TITLE
fixed a number of compile errors that seemed to stem from commit f05996441744a3eb7d223a5cc327cda603f13bd6

### DIFF
--- a/example_timeseries_plot/src/ofApp.cpp
+++ b/example_timeseries_plot/src/ofApp.cpp
@@ -38,7 +38,7 @@ void ofApp::update(){
     float tic = ofGetElapsedTimeMillis();
     float delta = tic-lastTic;
 
-    VectorDouble data(2);
+    vector<float> data(2);
 
     //Update the 1st plot
     data[0] = mouseX;

--- a/src/ofxGrtMatrixPlot.cpp
+++ b/src/ofxGrtMatrixPlot.cpp
@@ -1,7 +1,7 @@
 
 #include "ofxGrtMatrixPlot.h"
 
-GRT_BEGIN_NAMESPACE
+using namespace GRT;
 
 ofxGrtMatrixPlot::ofxGrtMatrixPlot(){
     rows = cols = 0;
@@ -53,28 +53,6 @@ void ofxGrtMatrixPlot::update( const Matrix<float> &data ){
     update( pixelPointer, rows, cols );
 }
 
-void ofxGrtMatrixPlot::update( const MatrixFloat &data ){
- 
-    const unsigned int rows = data.getNumRows(); 
-    const unsigned int cols = data.getNumCols();
-    const size_t size = rows*cols;
-
-    if( this->rows != rows || this->cols != cols ){
-        this->rows = rows;
-        this->cols = cols;
-        pixelData.resize( size );
-    }
-    
-    unsigned int index = 0;
-    for(unsigned int j=0; j<cols; j++){
-        for(unsigned int i=0; i<rows; i++){
-            pixelData[ index++ ] = data[i][j];
-        }
-    }
-    float *pixelPointer = &pixelData[0];
-
-    update( pixelPointer, rows, cols );
-}
 
 void ofxGrtMatrixPlot::update( float *data, const unsigned int rows, const unsigned int cols ){
     
@@ -119,5 +97,5 @@ unsigned int ofxGrtMatrixPlot::getCols() const{
     return this->cols;
 }
 
-GRT_END_NAMESPACE
+
 

--- a/src/ofxGrtMatrixPlot.h
+++ b/src/ofxGrtMatrixPlot.h
@@ -25,14 +25,13 @@
 #include "ofTexture.h"
 #include "ofConstants.h"
 
-GRT_BEGIN_NAMESPACE
+using namespace GRT;
 
 class ofxGrtMatrixPlot {
 public:
     ofxGrtMatrixPlot();
     void update( const Matrix<double> &data );
     void update( const Matrix<float> &data );
-    void update( const MatrixFloat &data );
     void update( float *data, const unsigned int rows, const unsigned int cols );
     bool draw(float x, float y) const;
     bool draw(float x, float y, float w, float h) const;
@@ -42,9 +41,9 @@ public:
 protected:
     unsigned int rows;
     unsigned int cols;
-    Vector<float> pixelData;
+    vector<float> pixelData;
     ofFloatPixels pixels;
     ofTexture texture;
 };
 
-GRT_END_NAMESPACE
+

--- a/src/ofxGrtTimeseriesPlot.cpp
+++ b/src/ofxGrtTimeseriesPlot.cpp
@@ -1,6 +1,6 @@
 #include "ofxGrtTimeseriesPlot.h"
 
-GRT_BEGIN_NAMESPACE
+using namespace GRT;
     
 ofxGrtTimeseriesPlot::ofxGrtTimeseriesPlot(){
     plotTitle = "";
@@ -42,11 +42,11 @@ bool ofxGrtTimeseriesPlot::setup(unsigned int timeseriesLength,unsigned int numD
     this->timeseriesLength = timeseriesLength;
     this->numDimensions = numDimensions;
     this->plotTitle = title;
-    dataBuffer.resize(timeseriesLength, VectorFloat(numDimensions,0));
+    dataBuffer.resize(timeseriesLength, vector<float>(numDimensions,0));
     
     //Fill the buffer with empty values
     for(unsigned int i=0; i<timeseriesLength; i++)
-        dataBuffer.push_back(VectorFloat(numDimensions,0));
+        dataBuffer.push_back(vector<float>(numDimensions,0));
     
     lockRanges = false;
     minY = 0;
@@ -81,7 +81,7 @@ bool ofxGrtTimeseriesPlot::reset(){
     }
 
     //Clear the buffer
-    dataBuffer.setAllValues(VectorFloat(numDimensions,0));
+    dataBuffer.setAllValues(vector<float>(numDimensions,0));
     
     return true;
 }
@@ -96,7 +96,7 @@ bool ofxGrtTimeseriesPlot::setRanges(float minY,float maxY,bool lockRanges){
     return true;
 }
     
-bool ofxGrtTimeseriesPlot::setData( const Vector< VectorFloat > &data ){
+bool ofxGrtTimeseriesPlot::setData( const vector< vector<float> > &data ){
     
     const unsigned int M = (unsigned int)data.size();
     dataBuffer.reset();
@@ -111,7 +111,7 @@ bool ofxGrtTimeseriesPlot::setData( const Vector< VectorFloat > &data ){
     return true;
 }
     
-bool ofxGrtTimeseriesPlot::setData( const MatrixFloat &data ){
+bool ofxGrtTimeseriesPlot::setData( const Matrix<float> &data ){
     
     const unsigned int M = data.getNumRows();
     const unsigned int N = data.getNumCols();
@@ -124,7 +124,7 @@ bool ofxGrtTimeseriesPlot::setData( const MatrixFloat &data ){
     dataBuffer.reset();
     
     for(unsigned int i=0; i<M; i++){
-        update( data.getRow(i) );
+        update( data.getRowVector(i) );
     }
     
     return true;
@@ -141,9 +141,9 @@ bool ofxGrtTimeseriesPlot::update(){
     return true;
 }
 
-bool ofxGrtTimeseriesPlot::update( const VectorFloat &data ){
+bool ofxGrtTimeseriesPlot::update( const vector<float> &data ){
 
-    const unsigned int N = data.getSize();
+    const unsigned int N = data.size();
     
     //If the buffer has not been initialised then return false, otherwise update the buffer
     if( !initialized || N != numDimensions ) return false;
@@ -162,6 +162,8 @@ bool ofxGrtTimeseriesPlot::update( const VectorFloat &data ){
     return true;
     
 }
+
+
     
 bool ofxGrtTimeseriesPlot::draw(unsigned int x,unsigned int y,unsigned int w,unsigned int h){
     
@@ -267,5 +269,5 @@ bool ofxGrtTimeseriesPlot::draw(unsigned int x,unsigned int y,unsigned int w,uns
     return true;
 }
 
-GRT_END_NAMESPACE
+
 

--- a/src/ofxGrtTimeseriesPlot.h
+++ b/src/ofxGrtTimeseriesPlot.h
@@ -22,7 +22,7 @@
 #include "ofMain.h"
 #include "GRT/GRT.h"
 
-GRT_BEGIN_NAMESPACE
+using namespace GRT;
 
 class ofxGrtTimeseriesPlot{
 public:
@@ -50,7 +50,8 @@ public:
      @brief updates the plot pushing the input data into the plots internal buffer. The size of the input Vector must match the number of dimensions in the plot.
      @return returns true if the plot was updated successfully, false otherwise
     */
-    bool update( const VectorFloat &data );
+    bool update( const vector<float> &data );
+    //bool update( const vector<double> &data );
 
     /**
      @brief draws the plot.     
@@ -59,8 +60,8 @@ public:
     bool draw(unsigned int x,unsigned int y,unsigned int w,unsigned int h);
     
     bool reset();
-    bool setData( const Vector< VectorFloat > &data );
-    bool setData( const MatrixFloat &data );
+    bool setData( const vector< vector<float> > &data );
+    bool setData( const Matrix<float> &data );
     bool setRanges(float minY,float maxY,bool lockRanges = false);
     bool setDrawGrid( bool drawGrid ){ this->drawGrid = drawGrid; return true; }
     bool setFont( const ofTrueTypeFont &font ){ this->font = &font; return this->font->isLoaded(); }
@@ -73,9 +74,9 @@ protected:
     float minY;
     float maxY;
     std::string plotTitle;
-    Vector< std::string > channelNames;
-    Vector< bool > channelVisible;
-    CircularBuffer< VectorFloat > dataBuffer;
+    vector< std::string > channelNames;
+    vector< bool > channelVisible;
+    CircularBuffer< vector<float> > dataBuffer;
     
     bool initialized;
     bool lockRanges;
@@ -86,10 +87,10 @@ protected:
     ofColor textColor;
     ofColor gridColor;
     ofColor backgroundColor;
-    Vector< ofColor > colors;
+    vector< ofColor > colors;
     ErrorLog errorLog;
     const ofTrueTypeFont *font;
     
 };
 
-GRT_END_NAMESPACE
+


### PR DESCRIPTION
This basically reverts to pre commit f05996441744a3eb7d223a5cc327cda603f13bd6 

The current master 41775b5c082f4c69c4f3c138fc46bb7b11fca27b gave me ~20 compile errors which seemed to be derived from f05996441744a3eb7d223a5cc327cda603f13bd6  The code now compiles and runs using of_v20151109_osx_release.  There are one or two places where I made potentially more meaningful changes e.g. from double to float without much oversight, as compared to making the syntax more general.    
