### PR TITLE
Timeseries highlighting

### DIFF
--- a/example_timeseries_plot/src/ofApp.cpp
+++ b/example_timeseries_plot/src/ofApp.cpp
@@ -43,7 +43,11 @@ void ofApp::update(){
     //Update the 1st plot
     data[0] = mouseX;
     data[1] = mouseY;
-    plot1.update( data );
+    if (abs(mouseX - lastX) > abs(mouseY - lastY))
+        plot1.update( data, 1, "Horizontal" );
+    else if (abs(mouseX - lastX) < abs(mouseY - lastY))
+        plot1.update( data, 2, "Vertical" );
+    else plot1.update( data );
 
     //Update the 2nd plot
     data[0] = lastX > 0 ? (mouseX-lastX) / delta : 0.0;

--- a/src/ofxGrtTimeseriesPlot.h
+++ b/src/ofxGrtTimeseriesPlot.h
@@ -48,15 +48,19 @@ public:
     
     /**
      @brief updates the plot pushing the input data into the plots internal buffer. The size of the input Vector must match the number of dimensions in the plot.
+     @param highlight whether or not to highlight the newly added data point (default false)
+     @param label the label associated with the highlight
      @return returns true if the plot was updated successfully, false otherwise
     */
-    bool update( const vector<float> &data );
-    
+    bool update( const vector<float> &data, bool highlight = false, std::string label = "" );
+
     /**
      @brief updates the plot pushing the input data into the plots internal buffer. The size of the input Vector must match the number of dimensions in the plot.
+     @param highlight whether or not to highlight the newly added data point (default false)
+     @param label the label associated with the highlight
      @return returns true if the plot was updated successfully, false otherwise
     */
-    bool update( const vector<double> &data );
+    bool update( const vector<double> &data, bool highlight = false, std::string label = "" );
 
     /**
      @brief draws the plot.     
@@ -291,7 +295,9 @@ protected:
     vector< bool > channelVisible;
     vector< std::pair<float,float> > channelRanges;
     CircularBuffer< vector<float> > dataBuffer;
-    
+    CircularBuffer< int > highlightBuffer;
+    CircularBuffer< std::string > labelBuffer;
+
     bool initialized;
     bool lockRanges; ///< If true, then the min/max values for the plots will not be updated
     bool linkRanges; ///< If true, then the min/max values for the plots will be based on the global min/max values across all channels, if false then the min/max values will be based per channel


### PR DESCRIPTION
Add the ability to specify a label (int and string) for each data point added to the time series plot. These are then rendered with a lighter gray background and a label.

Update the example_timeseries_plot example to demonstrate the use of this highlighting.
