### PR TITLE
Allow rendering of axis titles inside or outside of plots dimensions.

### DIFF
--- a/src/ofxGrtTimeseriesPlot.cpp
+++ b/src/ofxGrtTimeseriesPlot.cpp
@@ -27,6 +27,8 @@ ofxGrtTimeseriesPlot::ofxGrtTimeseriesPlot(){
     errorLog.setProceedingText("[ERROR ofxGrtTimeseriesPlot]");
     xAxisInfo = "X";
     yAxisInfo = "   Y";
+    insetPlotByInfoMarginX = true;
+    insetPlotByInfoMarginY = true;
 }
 
 ofxGrtTimeseriesPlot::~ofxGrtTimeseriesPlot(){
@@ -702,8 +704,7 @@ bool ofxGrtTimeseriesPlot::update( const vector<double> &data, std::string label
     
 }
     
-bool ofxGrtTimeseriesPlot::draw( const unsigned int x, const unsigned int y, const unsigned int w, const unsigned int h ){
-
+bool ofxGrtTimeseriesPlot::draw( int x, int y, int w, int h ){
     std::unique_lock<std::mutex> lock( mtx );
     
     if( !initialized ) return false;
@@ -768,6 +769,16 @@ bool ofxGrtTimeseriesPlot::draw( const unsigned int x, const unsigned int y, con
         }
     }
     
+    if (!insetPlotByInfoMarginX) {
+        x -= config->info_margin;
+        w += config->info_margin;
+    }
+
+    if (!insetPlotByInfoMarginY) {
+        y -= config->info_margin;
+        h += config->info_margin;
+    }
+
     ofPushMatrix();
     ofEnableAlphaBlending();
     ofTranslate(x, y);

--- a/src/ofxGrtTimeseriesPlot.h
+++ b/src/ofxGrtTimeseriesPlot.h
@@ -92,7 +92,7 @@ public:
      @brief draws the plot.     
      @return returns true if the plot was drawn successfully, false otherwise
     */
-    bool draw( const unsigned int x, const unsigned int y, const unsigned int w, const unsigned int h );
+    bool draw( int x, int y, int w, int h );
     
     /**
      @brief draws labled plot.
@@ -324,6 +324,17 @@ public:
         this->backgroundColor = backgroundColor;
         return true;
     }
+  
+    /**
+     @brief Whether or not to count the axis labels as part of the plot width and height.
+     @param x: if true, the plot's x position and width will refer to the width of the plot plus the y-axis label (which is drawn outside of the plot itself). if false, the x position and width will refer to just the plot itself, with the y-axis label drawn outside of this area.
+     @param y: if true, the plot's y position and height will refer to the height of the plot plus the x-axis label (which is drawn outside of the plot itself). if false, the y position and height will refer to just the plot itself, with the x-axis label drawn outside of this area.
+     */
+    bool setIncludeAxisLabelsInPlotDimensions(bool x, bool y) {
+        insetPlotByInfoMarginX = x;
+        insetPlotByInfoMarginY = y;
+        return true;
+    }
 
     /**
      @brief gets the global min and max range information.
@@ -375,6 +386,7 @@ protected:
     CircularBuffer< std::string > labelBuffer;
     
     std::string xAxisInfo, yAxisInfo;
+    bool insetPlotByInfoMarginX, insetPlotByInfoMarginY;
     
     bool initialized;
     bool lockRanges; ///< If true, then the min/max values for the plots will not be updated


### PR DESCRIPTION
Adds a function setIncludeAxisLabelsInPlotDimensions(bool x, bool y)
that allows the user to specify whether the axis titles (which are
rendered outside of the plot itself) should be counted as part of the
plot’s dimensions (x and width, y and height) or rendered outside of
them.

Fixes https://github.com/nickgillian/ofxGrt/issues/18.
