### PR TITLE
Fix: adjust height, not top, when insetting for x-axis label.

### DIFF
--- a/src/ofxGrtTimeseriesPlot.cpp
+++ b/src/ofxGrtTimeseriesPlot.cpp
@@ -775,7 +775,6 @@ bool ofxGrtTimeseriesPlot::draw( int x, int y, int w, int h ){
     }
 
     if (!insetPlotByInfoMarginY) {
-        y -= config->info_margin;
         h += config->info_margin;
     }
 


### PR DESCRIPTION
The label is drawn at the bottom of the plot, so it only affects the height of the plot, not its top Y coordinate. That is, we should only adjust the height, not the y-coordinate, when insetting.
